### PR TITLE
prepare_proteins: setUpESMFold2 + Boltz-2 ccd_ligands

### DIFF
--- a/prepare_proteins/_prepare_sequences.py
+++ b/prepare_proteins/_prepare_sequences.py
@@ -1272,12 +1272,17 @@ class sequenceModels:
                 fh.write(script_body)
 
             launcher_model_dir = _launcher_cd_path(model_dir)
+            # Use the env's interpreter explicitly rather than `source
+            # activate`: in non-interactive SLURM batch shells `source
+            # activate <env>` silently fails to switch, leaving the base
+            # miniforge python (which may shadow `esm` with a different
+            # package) on PATH.
+            env_python = shlex.quote(os.path.join(esmfold2_env, "bin", "python"))
             command_lines = [
                 'ESMFOLD2_START_DIR="$(pwd)"',
                 f"cd {shlex.quote(launcher_model_dir)}",
                 f"export HF_HOME={shlex.quote(hf_cache)}",
-                f"source activate {shlex.quote(esmfold2_env)}",
-                "python fold.py",
+                f"{env_python} fold.py",
                 'cd "$ESMFOLD2_START_DIR"',
             ]
             commands.append("\n".join(command_lines) + "\n")

--- a/prepare_proteins/_prepare_sequences.py
+++ b/prepare_proteins/_prepare_sequences.py
@@ -1000,7 +1000,8 @@ class sequenceModels:
         num_loops=3,
         num_sampling_steps=200,
         num_diffusion_samples=1,
-        seed=None,
+        samples_per_call=5,
+        seed=0,
         esmfold2_env='/gpfs/projects/bsc72/conda_envs/esmfold2',
         hf_cache='/gpfs/projects/bsc72/mfloor/envs/huggingface_cache',
         model_name='biohub/ESMFold2',
@@ -1048,9 +1049,27 @@ class sequenceModels:
         num_sampling_steps : int, optional
             Diffusion sampling steps (default 200).
         num_diffusion_samples : int, optional
-            Number of diffusion samples per model (default 1).
+            Number of diffusion poses per model (default 1). When > 1, poses
+            are written as ``output/pose_000.cif`` ... ``pose_<N-1>.cif``;
+            a single pose is written as ``output/<model>.cif`` (back-compat).
+        samples_per_call : int, optional
+            ``num_diffusion_samples`` per ESMFold2 ``fold`` call (default 5).
+            The ensemble is drawn in chunks of this size so batching a large
+            pose count at once cannot OOM the GPU; the trunk is re-run per
+            chunk but each chunk reuses one trunk pass for its samples.
         seed : int, optional
-            Diffusion RNG seed. Default None (random per run).
+            Base diffusion RNG seed (default 0); chunk ``c`` uses ``seed + c``
+            for reproducible, non-overlapping pose draws. Pass ``None`` for a
+            random seed per call.
+
+        Multi-chain input
+        -----------------
+        When a model's sequence is a ``dict`` (``{chain_id: seq}``) or a
+        ``list`` of sequences, every chain is folded as its own
+        ``ProteinInput`` (e.g. receptor + peptide for a binding complex).
+        Only the first chain consumes the per-model MSA (``msa_dir``);
+        additional chains are folded single-sequence, matching the usual
+        peptide-protein cofolder convention.
         esmfold2_env : str, optional
             Path to the conda env containing ``esm``. Default points at the
             shared MN5 deployment.
@@ -1178,7 +1197,10 @@ class sequenceModels:
             output_dir = os.path.join(model_dir, 'output')
             os.makedirs(output_dir, exist_ok=True)
 
-            cif_target = os.path.join(output_dir, f"{model_name_iter}.cif")
+            if num_diffusion_samples == 1:
+                cif_target = os.path.join(output_dir, f"{model_name_iter}.cif")
+            else:
+                cif_target = os.path.join(output_dir, f"pose_{num_diffusion_samples - 1:03d}.cif")
             if skip_finished and os.path.exists(cif_target):
                 continue
 
@@ -1187,12 +1209,26 @@ class sequenceModels:
             all_ligs = ccd_ligs + smiles_ligs
             msa_path = _msa_for_model(model_name_iter)
 
-            sequence = self.sequences[model_name_iter]
-            if isinstance(sequence, dict):
-                first_chain = next(iter(sequence.values()))
-                sequence = first_chain if isinstance(first_chain, str) else str(first_chain)
+            # Build the protein chain list (receptor + optional peptide / extra
+            # chains). Only the first chain consumes the MSA; the rest are
+            # single-sequence.
+            raw_sequence = self.sequences[model_name_iter]
+            if isinstance(raw_sequence, dict):
+                chain_seqs = [(str(cid), str(seq).strip().upper())
+                              for cid, seq in raw_sequence.items() if seq]
+            elif isinstance(raw_sequence, (list, tuple)):
+                chain_seqs = [(chr(ord('A') + i), str(seq).strip().upper())
+                              for i, seq in enumerate(raw_sequence) if seq]
+            else:
+                chain_seqs = [('A', str(raw_sequence).strip().upper())]
+            # chains: list of (chain_id, sequence, msa_path_or_None)
+            chains = [
+                (cid, seq, msa_path if i == 0 else None)
+                for i, (cid, seq) in enumerate(chain_seqs)
+            ]
 
             script_path = os.path.join(model_dir, 'fold.py')
+            any_msa = any(c[2] for c in chains)
             script_body = textwrap.dedent(f'''\
                 """Auto-generated ESMFold2 fold script for {model_name_iter}."""
                 import json
@@ -1205,30 +1241,38 @@ class sequenceModels:
                     ProteinInput, LigandInput, StructurePredictionInput,
                 )
                 from esm.models.esmfold2 import ESMFold2InputBuilder
+                {"from esm.utils.msa import MSA" if any_msa else ""}
                 from transformers.models.esmfold2.modeling_esmfold2 import ESMFold2Model
-                {"from esm.utils.msa import MSA" if msa_path else ""}
 
                 MODEL_ID = {model_name_iter!r}
-                SEQUENCE = {sequence!r}
+                CHAINS = {chains!r}          # list of (chain_id, sequence, msa_path_or_None)
                 LIGANDS = {all_ligs!r}
-                MSA_PATH = {msa_path!r}
                 OUTPUT_DIR = 'output'
                 NUM_LOOPS = {num_loops}
                 NUM_SAMPLING_STEPS = {num_sampling_steps}
                 NUM_DIFFUSION_SAMPLES = {num_diffusion_samples}
+                SAMPLES_PER_CALL = {samples_per_call}
                 SEED = {seed!r}
 
                 os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+                def _load_msa(path):
+                    if not path:
+                        return None
+                    m = MSA.from_a3m(path=path, remove_insertions=True, max_sequences=1000)
+                    print(f"[esmfold2]   MSA {{path}}: depth={{m.depth}}, length={{m.seqlen}}", flush=True)
+                    return m
+
+
                 t0 = time.time()
                 model = ESMFold2Model.from_pretrained({model_name!r}).cuda().eval()
                 print(f"[esmfold2] model loaded in {{time.time()-t0:.1f}}s", flush=True)
 
-                msa = None
-                if MSA_PATH:
-                    msa = MSA.from_a3m(path=MSA_PATH, remove_insertions=True, max_sequences=1000)
-                    print(f"[esmfold2] MSA depth={{msa.depth}}, length={{msa.seqlen}}", flush=True)
-
-                seqs = [ProteinInput(id="A", sequence=SEQUENCE, msa=msa)]
+                seqs = [
+                    ProteinInput(id=cid, sequence=seq, msa=_load_msa(mp))
+                    for (cid, seq, mp) in CHAINS
+                ]
                 for lig in LIGANDS:
                     if "ccd" in lig:
                         seqs.append(LigandInput(id=lig["id"], ccd=[lig["ccd"]]))
@@ -1236,33 +1280,56 @@ class sequenceModels:
                         seqs.append(LigandInput(id=lig["id"], smiles=lig["smiles"]))
 
                 spi = StructurePredictionInput(sequences=seqs)
+                print(f"[esmfold2] folding {{MODEL_ID}}: "
+                      + ", ".join(f"{{cid}}={{len(seq)}}aa" for cid, seq, _ in CHAINS)
+                      + f", {{len(LIGANDS)}} ligands, {{NUM_DIFFUSION_SAMPLES}} poses", flush=True)
 
+                builder = ESMFold2InputBuilder()
+                poses = []
+                chunk = 0
                 t1 = time.time()
-                result = ESMFold2InputBuilder().fold(
-                    model, spi,
-                    num_loops=NUM_LOOPS,
-                    num_sampling_steps=NUM_SAMPLING_STEPS,
-                    num_diffusion_samples=NUM_DIFFUSION_SAMPLES,
-                    seed=SEED,
-                    complex_id=MODEL_ID,
-                )
+                while len(poses) < NUM_DIFFUSION_SAMPLES:
+                    k = min(SAMPLES_PER_CALL, NUM_DIFFUSION_SAMPLES - len(poses))
+                    seed = (SEED + chunk) if SEED is not None else None
+                    res = builder.fold(
+                        model, spi,
+                        num_loops=NUM_LOOPS,
+                        num_sampling_steps=NUM_SAMPLING_STEPS,
+                        num_diffusion_samples=k,
+                        seed=seed,
+                        complex_id=MODEL_ID,
+                    )
+                    poses.extend(res if isinstance(res, list) else [res])
+                    chunk += 1
+                    print(f"[esmfold2]   {{len(poses)}}/{{NUM_DIFFUSION_SAMPLES}} poses", flush=True)
+                poses = poses[:NUM_DIFFUSION_SAMPLES]
                 fold_t = time.time() - t1
-                print(f"[esmfold2] folded in {{fold_t:.1f}}s", flush=True)
+                print(f"[esmfold2] folded {{len(poses)}} poses in {{fold_t:.1f}}s", flush=True)
 
-                with open(os.path.join(OUTPUT_DIR, MODEL_ID + ".cif"), "w") as fh:
-                    fh.write(result.complex.to_mmcif())
+                # Single pose -> <model>.cif (back-compat); ensemble -> pose_NNN.cif.
+                stats_poses = []
+                for i, r in enumerate(poses):
+                    fname = (MODEL_ID + ".cif") if NUM_DIFFUSION_SAMPLES == 1 else f"pose_{{i:03d}}.cif"
+                    with open(os.path.join(OUTPUT_DIR, fname), "w") as fh:
+                        fh.write(r.complex.to_mmcif())
+                    stats_poses.append({{
+                        "pose": i,
+                        "ptm": float(r.ptm) if getattr(r, "ptm", None) is not None else None,
+                        "iptm": float(r.iptm) if getattr(r, "iptm", None) is not None else None,
+                        "plddt_mean": float(r.plddt.mean()) if getattr(r, "plddt", None) is not None else None,
+                    }})
 
                 stats = {{
                     "model_id": MODEL_ID,
-                    "n_residues": len(SEQUENCE),
+                    "n_chains": len(CHAINS),
+                    "chain_lengths": {{cid: len(seq) for cid, seq, _ in CHAINS}},
                     "n_ligands": len(LIGANDS),
-                    "msa_used": bool(MSA_PATH),
+                    "msa_used": any(mp for _, _, mp in CHAINS),
                     "num_loops": NUM_LOOPS,
                     "num_sampling_steps": NUM_SAMPLING_STEPS,
                     "num_diffusion_samples": NUM_DIFFUSION_SAMPLES,
                     "fold_wall_time_s": fold_t,
-                    "ptm": float(result.ptm) if hasattr(result, "ptm") else None,
-                    "plddt_mean": float(result.plddt.mean()) if hasattr(result, "plddt") else None,
+                    "poses": stats_poses,
                 }}
                 with open(os.path.join(OUTPUT_DIR, MODEL_ID + "_stats.json"), "w") as fh:
                     json.dump(stats, fh, indent=2)

--- a/prepare_proteins/_prepare_sequences.py
+++ b/prepare_proteins/_prepare_sequences.py
@@ -988,6 +988,302 @@ class sequenceModels:
 
         return commands
 
+    def setUpESMFold2(
+        self,
+        job_folder,
+        only_models=None,
+        exclude_models=None,
+        ligands=None,
+        ligand_smiles=None,
+        msa_dir=None,
+        msa_paths=None,
+        num_loops=3,
+        num_sampling_steps=200,
+        num_diffusion_samples=1,
+        seed=None,
+        esmfold2_env='/gpfs/projects/bsc72/conda_envs/esmfold2',
+        hf_cache='/gpfs/projects/bsc72/mfloor/envs/huggingface_cache',
+        model_name='biohub/ESMFold2',
+        skip_finished=False,
+    ):
+        """Create ESMFold2 job folders, per-model Python scripts, and shell commands.
+
+        ESMFold2 (Biohub, 2026, MIT-licensed) is a structure predictor that
+        supports CCD-coded cofactors and SMILES ligands, with optional MSA
+        input. Single-sequence mode (no MSA) gives ~10x speedup over
+        MSA-using methods at modest accuracy cost. This helper mirrors
+        :meth:`setUpAlphaFold3` — per-model dirs are created under
+        ``job_folder``, a per-model Python script is written, and the
+        returned commands ``cd`` into each model dir and run the script.
+
+        Parameters
+        ----------
+        job_folder : str
+            Root folder that will contain the per-model dirs.
+        only_models : str or iterable, optional
+            Restrict to the given model name(s).
+        exclude_models : str or iterable, optional
+            Skip the given model name(s).
+        ligands : optional
+            CCD-coded ligand specification applied to every model. Accepts:
+
+            * list/tuple of CCD codes (strings), e.g. ``["HEM", "MG"]``;
+            * dict mapping CCD code to a count, e.g. ``{"HEM": 1, "MG": 1}``;
+            * dict mapping model name (or ``"default"`` / ``"*"``) to any of
+              the above to override the default per model.
+        ligand_smiles : optional
+            SMILES ligand specification, same forms as ``ligands`` but with
+            SMILES strings instead of CCD codes.
+        msa_dir : str, optional
+            Directory containing ``<model>.a3m`` files. When provided and
+            the per-model MSA file exists, the model is folded in MSA mode.
+            Otherwise ESMFold2 runs in single-sequence mode (faster, lower
+            accuracy on hard targets).
+        msa_paths : dict, optional
+            Per-model overrides: ``{model_name: path_or_None}``. ``None``
+            forces single-sequence mode for that model even if ``msa_dir``
+            has a file. Takes precedence over ``msa_dir``.
+        num_loops : int, optional
+            Number of recycling loops (default 3).
+        num_sampling_steps : int, optional
+            Diffusion sampling steps (default 200).
+        num_diffusion_samples : int, optional
+            Number of diffusion samples per model (default 1).
+        seed : int, optional
+            Diffusion RNG seed. Default None (random per run).
+        esmfold2_env : str, optional
+            Path to the conda env containing ``esm``. Default points at the
+            shared MN5 deployment.
+        hf_cache : str, optional
+            HuggingFace cache directory. Pre-populated for offline use on
+            compute nodes.
+        model_name : str, optional
+            HuggingFace model identifier (default ``"biohub/ESMFold2"``).
+        skip_finished : bool, optional
+            When ``True``, models with an existing ``output/<model>.cif`` are
+            skipped.
+
+        Returns
+        -------
+        list[str]
+            One multi-line command per prepared ESMFold2 job, ready for
+            ``bsc_calculations.mn5.jobArrays`` or direct execution.
+        """
+        import textwrap
+
+        if isinstance(only_models, str):
+            only_models = [only_models]
+        elif only_models:
+            only_models = list(only_models)
+        else:
+            only_models = []
+
+        if isinstance(exclude_models, str):
+            exclude_models = [exclude_models]
+        elif exclude_models:
+            exclude_models = list(exclude_models)
+        else:
+            exclude_models = []
+
+        os.makedirs(job_folder, exist_ok=True)
+
+        def _launcher_cd_path(path_value):
+            normalized_path = os.path.normpath(path_value)
+            if os.path.isabs(normalized_path):
+                return os.path.relpath(normalized_path, start=os.getcwd())
+            return normalized_path
+
+        def _ccd_ligands_for_model(name):
+            """Return list of {'id': str, 'ccd': str} dicts for this model."""
+            if not ligands:
+                return []
+            spec = ligands
+            if isinstance(ligands, dict):
+                # Check for per-model dict (keys look like model names, not CCD codes)
+                # Heuristic: if any key matches a known model, treat as per-model
+                model_keyed = any(
+                    k in self.sequences_names or k in ('default', '*')
+                    for k in ligands.keys()
+                )
+                if model_keyed:
+                    spec = ligands.get(name)
+                    if spec is None:
+                        spec = ligands.get('default') or ligands.get('*')
+                    if not spec:
+                        return []
+            return _expand_ccd_spec(spec)
+
+        def _expand_ccd_spec(spec):
+            if isinstance(spec, (list, tuple)):
+                # list of CCD code strings
+                out = []
+                counts = defaultdict(int)
+                for code in spec:
+                    code_str = str(code).upper()
+                    counts[code_str] += 1
+                    suffix = chr(ord('A') + counts[code_str] - 1)
+                    out.append({"id": f"{code_str}{suffix}", "ccd": code_str})
+                return out
+            if isinstance(spec, dict):
+                # {code: count}
+                out = []
+                for code, count in spec.items():
+                    code_str = str(code).upper()
+                    for i in range(int(count)):
+                        suffix = chr(ord('A') + i)
+                        out.append({"id": f"{code_str}{suffix}", "ccd": code_str})
+                return out
+            raise ValueError(f"Unsupported ligand spec: {spec!r}")
+
+        def _smiles_ligands_for_model(name):
+            if not ligand_smiles:
+                return []
+            spec = ligand_smiles
+            if isinstance(ligand_smiles, dict):
+                model_keyed = any(
+                    k in self.sequences_names or k in ('default', '*')
+                    for k in ligand_smiles.keys()
+                )
+                if model_keyed:
+                    spec = ligand_smiles.get(name)
+                    if spec is None:
+                        spec = ligand_smiles.get('default') or ligand_smiles.get('*')
+                    if not spec:
+                        return []
+            if isinstance(spec, (list, tuple)):
+                out = []
+                for i, smi in enumerate(spec):
+                    out.append({"id": f"L{i+1}", "smiles": str(smi)})
+                return out
+            raise ValueError(f"Unsupported SMILES spec: {spec!r}")
+
+        def _msa_for_model(name):
+            if msa_paths and name in msa_paths:
+                return msa_paths[name]
+            if msa_dir:
+                cand = os.path.join(msa_dir, f"{name}.a3m")
+                if os.path.exists(cand):
+                    return cand
+            return None
+
+        commands = []
+        for model_name_iter in self.sequences_names:
+            if only_models and model_name_iter not in only_models:
+                continue
+            if model_name_iter in exclude_models:
+                continue
+
+            model_dir = os.path.join(job_folder, model_name_iter)
+            os.makedirs(model_dir, exist_ok=True)
+            output_dir = os.path.join(model_dir, 'output')
+            os.makedirs(output_dir, exist_ok=True)
+
+            cif_target = os.path.join(output_dir, f"{model_name_iter}.cif")
+            if skip_finished and os.path.exists(cif_target):
+                continue
+
+            ccd_ligs = _ccd_ligands_for_model(model_name_iter)
+            smiles_ligs = _smiles_ligands_for_model(model_name_iter)
+            all_ligs = ccd_ligs + smiles_ligs
+            msa_path = _msa_for_model(model_name_iter)
+
+            sequence = self.sequences[model_name_iter]
+            if isinstance(sequence, dict):
+                first_chain = next(iter(sequence.values()))
+                sequence = first_chain if isinstance(first_chain, str) else str(first_chain)
+
+            script_path = os.path.join(model_dir, 'fold.py')
+            script_body = textwrap.dedent(f'''\
+                """Auto-generated ESMFold2 fold script for {model_name_iter}."""
+                import json
+                import os
+                import time
+
+                import torch
+
+                from esm.utils.structure.input_builder import (
+                    ProteinInput, LigandInput, StructurePredictionInput,
+                )
+                from esm.models.esmfold2 import ESMFold2InputBuilder
+                from transformers.models.esmfold2.modeling_esmfold2 import ESMFold2Model
+                {"from esm.utils.msa import MSA" if msa_path else ""}
+
+                MODEL_ID = {model_name_iter!r}
+                SEQUENCE = {sequence!r}
+                LIGANDS = {all_ligs!r}
+                MSA_PATH = {msa_path!r}
+                OUTPUT_DIR = 'output'
+                NUM_LOOPS = {num_loops}
+                NUM_SAMPLING_STEPS = {num_sampling_steps}
+                NUM_DIFFUSION_SAMPLES = {num_diffusion_samples}
+                SEED = {seed!r}
+
+                os.makedirs(OUTPUT_DIR, exist_ok=True)
+                t0 = time.time()
+                model = ESMFold2Model.from_pretrained({model_name!r}).cuda().eval()
+                print(f"[esmfold2] model loaded in {{time.time()-t0:.1f}}s", flush=True)
+
+                msa = None
+                if MSA_PATH:
+                    msa = MSA.from_a3m(path=MSA_PATH, remove_insertions=True, max_sequences=1000)
+                    print(f"[esmfold2] MSA depth={{msa.depth}}, length={{msa.seqlen}}", flush=True)
+
+                seqs = [ProteinInput(id="A", sequence=SEQUENCE, msa=msa)]
+                for lig in LIGANDS:
+                    if "ccd" in lig:
+                        seqs.append(LigandInput(id=lig["id"], ccd=[lig["ccd"]]))
+                    elif "smiles" in lig:
+                        seqs.append(LigandInput(id=lig["id"], smiles=lig["smiles"]))
+
+                spi = StructurePredictionInput(sequences=seqs)
+
+                t1 = time.time()
+                result = ESMFold2InputBuilder().fold(
+                    model, spi,
+                    num_loops=NUM_LOOPS,
+                    num_sampling_steps=NUM_SAMPLING_STEPS,
+                    num_diffusion_samples=NUM_DIFFUSION_SAMPLES,
+                    seed=SEED,
+                    complex_id=MODEL_ID,
+                )
+                fold_t = time.time() - t1
+                print(f"[esmfold2] folded in {{fold_t:.1f}}s", flush=True)
+
+                with open(os.path.join(OUTPUT_DIR, MODEL_ID + ".cif"), "w") as fh:
+                    fh.write(result.complex.to_mmcif())
+
+                stats = {{
+                    "model_id": MODEL_ID,
+                    "n_residues": len(SEQUENCE),
+                    "n_ligands": len(LIGANDS),
+                    "msa_used": bool(MSA_PATH),
+                    "num_loops": NUM_LOOPS,
+                    "num_sampling_steps": NUM_SAMPLING_STEPS,
+                    "num_diffusion_samples": NUM_DIFFUSION_SAMPLES,
+                    "fold_wall_time_s": fold_t,
+                    "ptm": float(result.ptm) if hasattr(result, "ptm") else None,
+                    "plddt_mean": float(result.plddt.mean()) if hasattr(result, "plddt") else None,
+                }}
+                with open(os.path.join(OUTPUT_DIR, MODEL_ID + "_stats.json"), "w") as fh:
+                    json.dump(stats, fh, indent=2)
+                print(f"[esmfold2] DONE total={{time.time()-t0:.1f}}s", flush=True)
+                ''')
+            with open(script_path, 'w') as fh:
+                fh.write(script_body)
+
+            launcher_model_dir = _launcher_cd_path(model_dir)
+            command_lines = [
+                'ESMFOLD2_START_DIR="$(pwd)"',
+                f"cd {shlex.quote(launcher_model_dir)}",
+                f"export HF_HOME={shlex.quote(hf_cache)}",
+                f"source activate {shlex.quote(esmfold2_env)}",
+                "python fold.py",
+                'cd "$ESMFOLD2_START_DIR"',
+            ]
+            commands.append("\n".join(command_lines) + "\n")
+
+        return commands
+
     def copyModelsFromAlphaFoldCalculation(self, af_folder, output_folder, prefix='',
                                            return_missing=False, copy_all=False):
         """

--- a/prepare_proteins/_prepare_sequences.py
+++ b/prepare_proteins/_prepare_sequences.py
@@ -1209,6 +1209,17 @@ class sequenceModels:
             all_ligs = ccd_ligs + smiles_ligs
             msa_path = _msa_for_model(model_name_iter)
 
+            # Bundle MSA into the model dir as 'msa.a3m' so the generated
+            # fold.py references a relative path. The workspace is then
+            # portable: stage it locally, rsync to a cluster, and the
+            # launcher's `cd <model_dir>` makes the relative path resolve.
+            if msa_path and os.path.exists(msa_path):
+                import shutil
+                bundled = os.path.join(model_dir, 'msa.a3m')
+                if os.path.abspath(msa_path) != os.path.abspath(bundled):
+                    shutil.copyfile(msa_path, bundled)
+                msa_path = 'msa.a3m'
+
             # Build the protein chain list (receptor + optional peptide / extra
             # chains). Only the first chain consumes the MSA; the rest are
             # single-sequence.

--- a/prepare_proteins/_protein_models.py
+++ b/prepare_proteins/_protein_models.py
@@ -24129,15 +24129,17 @@ if __name__ == "__main__":
         output_format="pdb",
         use_potentials=False,
         ligands=None,
+        ccd_ligands=None,
         binder=None,
         chains=None
     ):
         """
         Run Boltz2 structure prediction and afinity.
 
-        It can be use to predict ligand binding with multiple ligands.
-        Additionally, it can be used to predict ligand binding affinity, but for just 1 ligand
-        Ligand/s should be given in SMILEs format.
+        It can be used to predict ligand binding with multiple ligands
+        (either as SMILES via ``ligands`` or as CCD codes via
+        ``ccd_ligands``). Additionally, it can be used to predict ligand
+        binding affinity, but for just 1 binder.
 
         To run in MN5 you need to precompute the MSA with AF3 or some other method!!!
 
@@ -24152,7 +24154,12 @@ if __name__ == "__main__":
         - recycling_steps: int. The number of recycling steps to use for prediction.
             AF3 uses by default 25 diffusion_samples and 10 recycling_steps.
         - use_potentials: bool. Whether to use the potentials for prediction. Set to True should improve performance, but uses more memmory.
-        - ligands (list[str]): list of ligands SMILEs
+        - ligands (list[str]): list of ligands SMILEs.
+        - ccd_ligands (list[str]): list of ligand CCD codes (e.g. ``["HEM",
+          "MG"]``). Useful for heme cofactors and metal ions where the
+          ligand structure is unambiguous from the CCD entry.
+          ``ccd_ligands`` and ``ligands`` can be combined; CCD ligands are
+          emitted first (conventional for cofactors), then SMILES ligands.
         - binder (str): chain of the binder/ligand to use to predict affinity. Only 1 binder is allowed
 
         chains : None, str, iterable or dict, optional
@@ -24199,12 +24206,22 @@ if __name__ == "__main__":
                 if use_msa_server == False:
                     iyf.write(f'      msa: {msa_path}+{model}.a3m\n')
 
+                # CCD-coded ligands first (cofactors / metals), then SMILES.
+                lig_chain_idx = 0
+                if ccd_ligands:
+                    for ccd in ccd_ligands:
+                        ligand_chain = chr(ord('B') + lig_chain_idx)
+                        iyf.write('  - ligand:\n')
+                        iyf.write(f'      id: [{ligand_chain}]\n')
+                        iyf.write(f"      ccd: {ccd}\n")
+                        lig_chain_idx += 1
                 if ligands != None:
-                    for i, ligand in enumerate(ligands):
-                        ligand_chain = chr(ord('B') + i)  # Assign chains starting from 'B'
+                    for ligand in ligands:
+                        ligand_chain = chr(ord('B') + lig_chain_idx)
                         iyf.write('  - ligand:\n')
                         iyf.write(f'      id: [{ligand_chain}]\n')
                         iyf.write(f"      smiles: '{ligand}'\n")
+                        lig_chain_idx += 1
 
                 if binder != None:
                     iyf.write('properties:\n')

--- a/tests/test_setUpBoltz2_ccd.py
+++ b/tests/test_setUpBoltz2_ccd.py
@@ -1,0 +1,93 @@
+"""Tests for proteinModels.setUpBoltz2Calculation CCD-ligand extension."""
+from pathlib import Path
+
+import prepare_proteins
+
+
+MODEL_PDB = """\
+ATOM      1  N   ALA A   1      11.104  13.207   2.100  1.00 20.00           N
+ATOM      2  CA  ALA A   1      12.560  13.207   2.100  1.00 20.00           C
+ATOM      3  C   ALA A   1      13.050  11.780   2.400  1.00 20.00           C
+ATOM      4  O   ALA A   1      12.410  10.801   2.000  1.00 20.00           O
+ATOM      5  N   GLY A   2      14.220  11.690   3.050  1.00 20.00           N
+ATOM      6  CA  GLY A   2      14.830  10.370   3.330  1.00 20.00           C
+ATOM      7  C   GLY A   2      15.412   9.850   2.010  1.00 20.00           C
+ATOM      8  OXT GLY A   2      15.962   8.743   1.970  1.00 20.00           O
+TER
+END
+"""
+
+
+def _load_models(tmp_path):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+    (models_dir / "modelA.pdb").write_text(MODEL_PDB)
+    return prepare_proteins.proteinModels(str(models_dir), conect_update=False)
+
+
+def _read_yaml(p):
+    return Path(p).read_text()
+
+
+def test_setup_boltz2_ccd_ligand_only(tmp_path):
+    models = _load_models(tmp_path)
+    job_folder = tmp_path / "boltz_jobs"
+    models.setUpBoltz2Calculation(str(job_folder), ccd_ligands=["HEM", "MG"])
+    yaml = _read_yaml(job_folder / "modelA" / "boltz.yaml")
+    assert "- protein:" in yaml
+    # First ligand at chain B (after protein at A), second at C
+    assert "id: [B]" in yaml
+    assert "ccd: HEM" in yaml
+    assert "id: [C]" in yaml
+    assert "ccd: MG" in yaml
+    # No SMILES section
+    assert "smiles" not in yaml
+
+
+def test_setup_boltz2_smiles_only_backward_compat(tmp_path):
+    """Existing SMILES-only call must keep working unchanged."""
+    models = _load_models(tmp_path)
+    job_folder = tmp_path / "boltz_jobs"
+    models.setUpBoltz2Calculation(str(job_folder), ligands=["CCO"])
+    yaml = _read_yaml(job_folder / "modelA" / "boltz.yaml")
+    assert "smiles: 'CCO'" in yaml
+    assert "id: [B]" in yaml
+    assert "ccd:" not in yaml
+
+
+def test_setup_boltz2_ccd_then_smiles_chain_ordering(tmp_path):
+    """CCD ligands occupy chains starting at B, then SMILES continue."""
+    models = _load_models(tmp_path)
+    job_folder = tmp_path / "boltz_jobs"
+    models.setUpBoltz2Calculation(
+        str(job_folder),
+        ccd_ligands=["HEM", "MG"],
+        ligands=["CCO"],
+    )
+    yaml = _read_yaml(job_folder / "modelA" / "boltz.yaml")
+    # Expected chains: A (protein), B (HEM), C (MG), D (CCO)
+    lines = yaml.splitlines()
+    # Find each ligand block and verify chain id
+    chain_to_kind = {}
+    cur_chain = None
+    for line in lines:
+        s = line.strip()
+        if s.startswith("id: [") and s.endswith("]"):
+            cur_chain = s[len("id: ["):-1]
+        elif s.startswith("ccd: "):
+            chain_to_kind[cur_chain] = ("ccd", s.split("ccd:", 1)[1].strip())
+        elif s.startswith("smiles:"):
+            chain_to_kind[cur_chain] = ("smiles", s.split("smiles:", 1)[1].strip())
+    assert chain_to_kind["B"] == ("ccd", "HEM")
+    assert chain_to_kind["C"] == ("ccd", "MG")
+    assert chain_to_kind["D"] == ("smiles", "'CCO'")
+
+
+def test_setup_boltz2_no_ligands(tmp_path):
+    """Calling without ligands or ccd_ligands still produces a protein-only YAML."""
+    models = _load_models(tmp_path)
+    job_folder = tmp_path / "boltz_jobs"
+    models.setUpBoltz2Calculation(str(job_folder))
+    yaml = _read_yaml(job_folder / "modelA" / "boltz.yaml")
+    assert "- protein:" in yaml
+    assert "- ligand:" not in yaml

--- a/tests/test_setUpESMFold2.py
+++ b/tests/test_setUpESMFold2.py
@@ -35,8 +35,7 @@ def test_setup_esmfold2_command_uses_relative_cd(tmp_path, monkeypatch):
         'ESMFOLD2_START_DIR="$(pwd)"',
         f"cd {shlex.quote(expected_model_dir)}",
         f"export HF_HOME={shlex.quote('/path/to/cache')}",
-        f"source activate {shlex.quote('/path/to/env')}",
-        "python fold.py",
+        f"{shlex.quote('/path/to/env/bin/python')} fold.py",
         'cd "$ESMFOLD2_START_DIR"',
     ]
     assert jobs[0].splitlines() == expected_lines

--- a/tests/test_setUpESMFold2.py
+++ b/tests/test_setUpESMFold2.py
@@ -89,7 +89,8 @@ def test_setup_esmfold2_msa_dir_autodetected(tmp_path, monkeypatch):
     models.setUpESMFold2(str(job_folder), msa_dir=str(msa_dir))
 
     script = (job_folder / "modelA" / "fold.py").read_text()
-    assert "MSA_PATH = " in script
+    # MSA wired as the 3rd element of the (chain_id, seq, msa) tuple in CHAINS
+    assert "CHAINS = " in script
     assert "modelA.a3m" in script
 
 
@@ -101,7 +102,66 @@ def test_setup_esmfold2_msa_disabled_without_dir(tmp_path, monkeypatch):
     models.setUpESMFold2(str(job_folder))
 
     script = (job_folder / "modelA" / "fold.py").read_text()
-    assert "MSA_PATH = None" in script
+    # single chain, no MSA -> msa element is None
+    assert "('A', 'ACDEFGHIK', None)" in script
+
+
+def test_setup_esmfold2_receptor_peptide_two_chains(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels(
+        {"cx": {"A": "ACDEFGHIKLMN", "B": "GRGDS"}}
+    )
+    job_folder = tmp_path / "esm"
+    models.setUpESMFold2(str(job_folder))
+
+    script = (job_folder / "cx" / "fold.py").read_text()
+    # two protein chains in CHAINS, folded as separate ProteinInputs
+    assert "('A', 'ACDEFGHIKLMN'" in script
+    assert "('B', 'GRGDS'" in script
+    assert "ProteinInput(id=cid, sequence=seq, msa=_load_msa(mp))" in script
+
+
+def test_setup_esmfold2_peptide_chain_single_seq_when_msa_on(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels(
+        {"cx": {"A": "ACDEFGHIKLMN", "B": "GRGDS"}}
+    )
+    msa_dir = tmp_path / "msas"
+    msa_dir.mkdir()
+    (msa_dir / "cx.a3m").write_text(">q\nACDEFGHIKLMN\n")
+
+    models.setUpESMFold2(str(tmp_path / "esm"), msa_dir=str(msa_dir))
+    script = (tmp_path / "esm" / "cx" / "fold.py").read_text()
+    # receptor (first chain) gets the MSA; peptide stays single-sequence (None)
+    assert "cx.a3m" in script
+    assert "('B', 'GRGDS', None)" in script
+
+
+def test_setup_esmfold2_pose_ensemble(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"cx": {"A": "ACDEFGHIKLMN", "B": "GRGDS"}})
+    models.setUpESMFold2(
+        str(tmp_path / "esm"), num_diffusion_samples=100, samples_per_call=10,
+    )
+    script = (tmp_path / "esm" / "cx" / "fold.py").read_text()
+    assert "NUM_DIFFUSION_SAMPLES = 100" in script
+    assert "SAMPLES_PER_CALL = 10" in script
+    assert "num_diffusion_samples=k" in script
+    assert 'pose_{i:03d}.cif' in script
+
+
+def test_setup_esmfold2_ensemble_skip_finished_checks_last_pose(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"cx": "ACDEFGHIK"})
+    jf = tmp_path / "esm"
+    (jf / "cx" / "output").mkdir(parents=True)
+    (jf / "cx" / "output" / "pose_009.cif").write_text("# done\n")
+    jobs = models.setUpESMFold2(str(jf), num_diffusion_samples=10, skip_finished=True)
+    assert jobs == []
 
 
 def test_setup_esmfold2_skip_finished(tmp_path, monkeypatch):

--- a/tests/test_setUpESMFold2.py
+++ b/tests/test_setUpESMFold2.py
@@ -1,0 +1,133 @@
+"""Tests for sequenceModels.setUpESMFold2."""
+import json
+import os
+import shlex
+
+import prepare_proteins
+import pytest
+
+
+def test_setup_esmfold2_creates_per_model_dirs_and_script(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm_jobs"
+
+    jobs = models.setUpESMFold2(str(job_folder))
+
+    assert len(jobs) == 1
+    assert (job_folder / "modelA").is_dir()
+    assert (job_folder / "modelA" / "output").is_dir()
+    assert (job_folder / "modelA" / "fold.py").is_file()
+
+
+def test_setup_esmfold2_command_uses_relative_cd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm jobs"
+
+    jobs = models.setUpESMFold2(str(job_folder), esmfold2_env="/path/to/env",
+                                hf_cache="/path/to/cache")
+
+    expected_model_dir = os.path.relpath(job_folder / "modelA", start=tmp_path)
+    expected_lines = [
+        'ESMFOLD2_START_DIR="$(pwd)"',
+        f"cd {shlex.quote(expected_model_dir)}",
+        f"export HF_HOME={shlex.quote('/path/to/cache')}",
+        f"source activate {shlex.quote('/path/to/env')}",
+        "python fold.py",
+        'cd "$ESMFOLD2_START_DIR"',
+    ]
+    assert jobs[0].splitlines() == expected_lines
+
+
+def test_setup_esmfold2_ccd_ligands_in_script(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm"
+    models.setUpESMFold2(str(job_folder), ligands=["HEM", "MG"])
+
+    script = (job_folder / "modelA" / "fold.py").read_text()
+    assert "'ccd': 'HEM'" in script or '"ccd": "HEM"' in script
+    assert "'ccd': 'MG'" in script or '"ccd": "MG"' in script
+
+
+def test_setup_esmfold2_ccd_ligands_dict_with_counts(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm"
+    models.setUpESMFold2(str(job_folder), ligands={"HEM": 2, "MG": 1})
+
+    script = (job_folder / "modelA" / "fold.py").read_text()
+    # 2 HEMs + 1 MG → 3 ligand entries
+    assert script.count("'ccd': 'HEM'") + script.count('"ccd": "HEM"') == 2
+    assert script.count("'ccd': 'MG'") + script.count('"ccd": "MG"') == 1
+
+
+def test_setup_esmfold2_smiles_ligands(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm"
+    models.setUpESMFold2(str(job_folder), ligand_smiles=["CCO"])
+
+    script = (job_folder / "modelA" / "fold.py").read_text()
+    assert "'smiles': 'CCO'" in script or '"smiles": "CCO"' in script
+
+
+def test_setup_esmfold2_msa_dir_autodetected(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    msa_dir = tmp_path / "msas"
+    msa_dir.mkdir()
+    (msa_dir / "modelA.a3m").write_text(">q\nACDEFGHIK\n")
+
+    job_folder = tmp_path / "esm"
+    models.setUpESMFold2(str(job_folder), msa_dir=str(msa_dir))
+
+    script = (job_folder / "modelA" / "fold.py").read_text()
+    assert "MSA_PATH = " in script
+    assert "modelA.a3m" in script
+
+
+def test_setup_esmfold2_msa_disabled_without_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm"
+    models.setUpESMFold2(str(job_folder))
+
+    script = (job_folder / "modelA" / "fold.py").read_text()
+    assert "MSA_PATH = None" in script
+
+
+def test_setup_esmfold2_skip_finished(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"modelA": "ACDEFGHIK"})
+    job_folder = tmp_path / "esm"
+    # Simulate prior completion
+    (job_folder / "modelA" / "output").mkdir(parents=True)
+    (job_folder / "modelA" / "output" / "modelA.cif").write_text("# already done\n")
+
+    jobs = models.setUpESMFold2(str(job_folder), skip_finished=True)
+    assert jobs == []
+
+
+def test_setup_esmfold2_only_models_and_exclude(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    models = prepare_proteins.sequenceModels({"a": "ACDEFG", "b": "GHIKLM", "c": "NPQRST"})
+    job_folder = tmp_path / "esm"
+
+    jobs_only = models.setUpESMFold2(str(job_folder / "only"), only_models="b")
+    assert len(jobs_only) == 1
+    assert (job_folder / "only" / "b").is_dir()
+    assert not (job_folder / "only" / "a").is_dir()
+
+    jobs_excl = models.setUpESMFold2(str(job_folder / "excl"), exclude_models=["b"])
+    assert len(jobs_excl) == 2

--- a/tests/test_setUpESMFold2.py
+++ b/tests/test_setUpESMFold2.py
@@ -89,9 +89,12 @@ def test_setup_esmfold2_msa_dir_autodetected(tmp_path, monkeypatch):
     models.setUpESMFold2(str(job_folder), msa_dir=str(msa_dir))
 
     script = (job_folder / "modelA" / "fold.py").read_text()
-    # MSA wired as the 3rd element of the (chain_id, seq, msa) tuple in CHAINS
+    # MSA is bundled into the model dir and referenced relatively, so the
+    # workspace stays portable across hosts.
     assert "CHAINS = " in script
-    assert "modelA.a3m" in script
+    assert "'msa.a3m'" in script
+    assert (job_folder / "modelA" / "msa.a3m").is_file()
+    assert (job_folder / "modelA" / "msa.a3m").read_text() == ">q\nACDEFGHIK\n"
 
 
 def test_setup_esmfold2_msa_disabled_without_dir(tmp_path, monkeypatch):
@@ -132,11 +135,14 @@ def test_setup_esmfold2_peptide_chain_single_seq_when_msa_on(tmp_path, monkeypat
     msa_dir.mkdir()
     (msa_dir / "cx.a3m").write_text(">q\nACDEFGHIKLMN\n")
 
-    models.setUpESMFold2(str(tmp_path / "esm"), msa_dir=str(msa_dir))
-    script = (tmp_path / "esm" / "cx" / "fold.py").read_text()
-    # receptor (first chain) gets the MSA; peptide stays single-sequence (None)
-    assert "cx.a3m" in script
+    jf = tmp_path / "esm"
+    models.setUpESMFold2(str(jf), msa_dir=str(msa_dir))
+    script = (jf / "cx" / "fold.py").read_text()
+    # Receptor (first chain) gets a bundled relative MSA; peptide stays
+    # single-sequence (None). The actual a3m is copied into the model dir.
+    assert "'msa.a3m'" in script
     assert "('B', 'GRGDS', None)" in script
+    assert (jf / "cx" / "msa.a3m").is_file()
 
 
 def test_setup_esmfold2_pose_ensemble(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- New ``sequenceModels.setUpESMFold2`` — high-level wrapper mirroring ``setUpAlphaFold3`` / ``setUpBoltz2Calculation``. Creates per-model dirs with auto-generated ``fold.py`` that runs ESMFold2 (Biohub, MIT-licensed) on the sequence, with CCD cofactors (HEM, MG, …), optional SMILES ligands, and optional MSA. Returns commands ready for ``bsc_calculations.mn5.jobArrays``.
- New ``ccd_ligands`` parameter on ``proteinModels.setUpBoltz2Calculation``. Backward-compatible: existing SMILES-only callers unchanged. CCD ligands occupy chains starting at ``B``, then SMILES continue the chain numbering.

## Motivation
The bisy UPO panel project needs cofactor-aware cofolding (UPO + HEM + Mg²⁺) under a commercial contract. AF3 outputs are restricted by the AF Server terms; Boltz-2 and ESMFold2 are the two MIT-licensed cofolders available. Both now need to be reachable from the same ``sequenceModels``/``proteinModels`` API used throughout the lab.

## Test plan
- [x] 9 unit tests for ``setUpESMFold2`` — per-model dirs, relative cd commands, CCD list / dict / SMILES, MSA dir autodetection, skip_finished, only/exclude.
- [x] 4 unit tests for the Boltz-2 CCD extension — CCD-only YAML, SMILES-only back-compat, CCD-then-SMILES chain ordering, protein-only fallback.
- [ ] End-to-end ESMFold2 smoke test on MN5 (job ``41144883`` queued at submission time, AacUPO + HEM + Mg) — separate validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)